### PR TITLE
Parse realtime

### DIFF
--- a/helpers.js
+++ b/helpers.js
@@ -24,6 +24,15 @@ const dateRange = function dateRange(date = Date()) {
   const format = 'YYYYMMDD';
 
   return {
+    realtime() {
+      const realtimeFormat = format + 'HH';
+      const startDate = dateObj;
+      const endDate = dateObj;
+      return {
+        start: formatDate(startDate, realtimeFormat),
+        end: formatDate(endDate, realtimeFormat),
+      };
+    },
     daily() {
       const startDate = dateObj;
       const endDate = dateObj;
@@ -74,6 +83,13 @@ function composeUrl(period, dates, options) {
   const decoded = {};
   decoded[options.indexKey] = options.cutLine > 50 ? 0 : 1;
   decoded[options.movedKey] = 'Y';
+  if (period === 'realtime') {
+    url = options.url.replace('day/', '');
+    decoded[options.movedKey] = 'N';
+    if (options.realtime) {
+      decoded[options.dayTime] = dates.start.toString();
+    }
+  }
   if (period === 'week') {
     url = options.url.replace('day', 'week');
     decoded[options.startDateKey] = dates.start.toString();

--- a/index.js
+++ b/index.js
@@ -13,6 +13,12 @@ function Melon(date, options) {
   const opts = populateOptions(options);
   const dateManager = dateRange(date);
   return {
+    realtime() {
+      const dates = dateManager.realtime();
+      const period = 'realtime';
+      const url = composeUrl(period, dates, opts);
+      return scrapeMelon(url, dates, opts);
+    },
     daily() {
       // NOTE: Dates are not needed for daily chart
       //       as Melon Music Chart does not provide previous daily charts.

--- a/test/structure.js
+++ b/test/structure.js
@@ -7,6 +7,10 @@ const options = {
 };
 const melon = Melon(options.date, options);
 
+test('length ranks - realtime', t => melon.realtime().then((chart) => {
+  t.is(chart.data.length, options.cutLine);
+}));
+
 test('length ranks - daily', t => melon.daily().then((chart) => {
   t.is(chart.data.length, options.cutLine);
 }));
@@ -19,6 +23,10 @@ test('length ranks - monthly', t => melon.monthly().then((chart) => {
   t.is(chart.data.length, options.cutLine);
 }));
 
+test('length JSON keys - realtime', t => melon.realtime().then((chart) => {
+  t.is(Object.keys(chart.data[0]).length, 4);
+}));
+
 test('length JSON keys - daily', t => melon.daily().then((chart) => {
   t.is(Object.keys(chart.data[0]).length, 4);
 }));
@@ -29,6 +37,13 @@ test('length JSON keys - weekly', t => melon.weekly().then((chart) => {
 
 test('length JSON keys - monthly', t => melon.monthly().then((chart) => {
   t.is(Object.keys(chart.data[0]).length, 4);
+}));
+
+test('data keys exist - realtime', t => melon.realtime().then((chart) => {
+  t.true(Object.keys(chart.data[0]).includes('rank'));
+  t.true(Object.keys(chart.data[0]).includes('title'));
+  t.true(Object.keys(chart.data[0]).includes('artist'));
+  t.true(Object.keys(chart.data[0]).includes('album'));
 }));
 
 test('data keys exist - daily', t => melon.daily().then((chart) => {
@@ -50,6 +65,11 @@ test('data keys exist - monthly', t => melon.monthly().then((chart) => {
   t.true(Object.keys(chart.data[0]).includes('title'));
   t.true(Object.keys(chart.data[0]).includes('artist'));
   t.true(Object.keys(chart.data[0]).includes('album'));
+}));
+
+test('date keys exist - realtime', t => melon.realtime().then((chart) => {
+  t.true(Object.keys(chart.dates).includes('start'));
+  t.true(Object.keys(chart.dates).includes('end'));
 }));
 
 test('date keys exist - daily', t => melon.daily().then((chart) => {


### PR DESCRIPTION
The "moved" URL that the other endpoints are using only returns
top 3 songs on realtime.
Due to this limitation, the implementation uses non-moved URL to
parse the ranks.
This results in slower processing time as Melon bootstraps many
things on non-moved URL page.

Resolves: #6